### PR TITLE
Leverage external API to deliver listings, locations, and details to the backend.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,4 @@
+
+*.xml
+.DS_Store
+spartanstay/spartanstay/src/main/java/com/spartanstay/spartanstay/service/Secrets.java

--- a/spartanstay/spartanstay/pom.xml
+++ b/spartanstay/spartanstay/pom.xml
@@ -17,6 +17,13 @@
 		<java.version>18</java.version>
 	</properties>
 	<dependencies>
+		<!-- https://mvnrepository.com/artifact/org.json/json -->
+		<dependency>
+			<groupId>org.json</groupId>
+			<artifactId>json</artifactId>
+			<version>20210307</version>
+		</dependency>
+
 		<dependency>
 			<groupId>org.springframework.boot</groupId>
 			<artifactId>spring-boot-starter-data-jpa</artifactId>

--- a/spartanstay/spartanstay/src/main/java/com/spartanstay/spartanstay/controller/ListingsController.java
+++ b/spartanstay/spartanstay/src/main/java/com/spartanstay/spartanstay/controller/ListingsController.java
@@ -1,5 +1,6 @@
 package com.spartanstay.spartanstay.controller;
 
+import com.spartanstay.spartanstay.service.ListingsServiceImpl;
 import com.spartanstay.spartanstay.service.Secrets;
 import org.springframework.format.annotation.DateTimeFormat;
 import org.springframework.web.bind.annotation.GetMapping;
@@ -7,37 +8,26 @@ import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
-import java.io.IOException;
-import java.net.URI;
-import java.net.http.HttpClient;
-import java.net.http.HttpRequest;
-import java.net.http.HttpResponse;
 import java.time.LocalDate;
-import java.util.Date;
 
 @RestController
 @RequestMapping("/listings")
 public class ListingsController {
-    @GetMapping("/NewYork")
-    String getNewYorkListings(@RequestParam("checkIn")
+
+    ListingsServiceImpl listingService = new ListingsServiceImpl();
+    @GetMapping("/rooms")
+    String getNewYorkListings(@RequestParam("destination") String destination, @RequestParam("checkIn")
                               @DateTimeFormat(iso = DateTimeFormat.ISO.DATE) LocalDate checkIn, @RequestParam("checkOut")
     @DateTimeFormat(iso = DateTimeFormat.ISO.DATE) LocalDate checkOut){
-        HttpRequest request = HttpRequest.newBuilder()
-                .uri(URI.create("https://hotels4.p.rapidapi.com/properties/list?destinationId=1506246&pageNumber=1&pageSize=25&checkIn="+checkIn+"&checkOut="+checkOut+"&adults1=1&sortOrder=PRICE&locale=en_US&currency=USD"))
-                .header("X-RapidAPI-Key", Secrets.API_KEY)
-                .header("X-RapidAPI-Host", "hotels4.p.rapidapi.com")
-                .method("GET", HttpRequest.BodyPublishers.noBody())
-                .build();
-        HttpResponse<String> response = null;
-        try {
-            response = HttpClient.newHttpClient().send(request, HttpResponse.BodyHandlers.ofString());
-        } catch (IOException e) {
-            throw new RuntimeException(e);
-        } catch (InterruptedException e) {
-            throw new RuntimeException(e);
+        String destId;
+        if (destination != null) {
+            //TODO: this needs to be a call to locations search, this won't work right now.
+            destId = destination;
         }
-        System.out.println(response.body());
+        else {
+            destId = "1506246";
+        }
 
-        return null;
+        return listingService.getListings(destId, checkIn.toString(), checkOut.toString(), "PRICE");
     }
 }

--- a/spartanstay/spartanstay/src/main/java/com/spartanstay/spartanstay/controller/ListingsController.java
+++ b/spartanstay/spartanstay/src/main/java/com/spartanstay/spartanstay/controller/ListingsController.java
@@ -16,18 +16,25 @@ public class ListingsController {
 
     ListingsServiceImpl listingService = new ListingsServiceImpl();
     @GetMapping("/rooms")
-    String getNewYorkListings(@RequestParam("destination") String destination, @RequestParam("checkIn")
+    String getRooms(@RequestParam("destination") String destination, @RequestParam("checkIn")
                               @DateTimeFormat(iso = DateTimeFormat.ISO.DATE) LocalDate checkIn, @RequestParam("checkOut")
     @DateTimeFormat(iso = DateTimeFormat.ISO.DATE) LocalDate checkOut){
         String destId;
         if (destination != null) {
-            //TODO: this needs to be a call to locations search, this won't work right now.
             destId = listingService.getLocationID(destination);
         }
         else {
             destId = "1506246";
         }
 
-        return listingService.getListings(destId, checkIn.toString(), checkOut.toString(), "PRICE");
+        return listingService.getListings(destId, checkIn.toString(), checkOut.toString(), "PRICE","1");
+    }
+
+    @GetMapping("/details")
+    String getDetails(@RequestParam("id") String id, @RequestParam("checkIn")
+    @DateTimeFormat(iso = DateTimeFormat.ISO.DATE) LocalDate checkIn, @RequestParam("checkOut")
+                              @DateTimeFormat(iso = DateTimeFormat.ISO.DATE) LocalDate checkOut){
+
+        return listingService.getDetails(id, checkIn.toString(), checkOut.toString(),"1");
     }
 }

--- a/spartanstay/spartanstay/src/main/java/com/spartanstay/spartanstay/controller/ListingsController.java
+++ b/spartanstay/spartanstay/src/main/java/com/spartanstay/spartanstay/controller/ListingsController.java
@@ -1,0 +1,43 @@
+package com.spartanstay.spartanstay.controller;
+
+import com.spartanstay.spartanstay.service.Secrets;
+import org.springframework.format.annotation.DateTimeFormat;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.io.IOException;
+import java.net.URI;
+import java.net.http.HttpClient;
+import java.net.http.HttpRequest;
+import java.net.http.HttpResponse;
+import java.time.LocalDate;
+import java.util.Date;
+
+@RestController
+@RequestMapping("/listings")
+public class ListingsController {
+    @GetMapping("/NewYork")
+    String getNewYorkListings(@RequestParam("checkIn")
+                              @DateTimeFormat(iso = DateTimeFormat.ISO.DATE) LocalDate checkIn, @RequestParam("checkOut")
+    @DateTimeFormat(iso = DateTimeFormat.ISO.DATE) LocalDate checkOut){
+        HttpRequest request = HttpRequest.newBuilder()
+                .uri(URI.create("https://hotels4.p.rapidapi.com/properties/list?destinationId=1506246&pageNumber=1&pageSize=25&checkIn="+checkIn+"&checkOut="+checkOut+"&adults1=1&sortOrder=PRICE&locale=en_US&currency=USD"))
+                .header("X-RapidAPI-Key", Secrets.API_KEY)
+                .header("X-RapidAPI-Host", "hotels4.p.rapidapi.com")
+                .method("GET", HttpRequest.BodyPublishers.noBody())
+                .build();
+        HttpResponse<String> response = null;
+        try {
+            response = HttpClient.newHttpClient().send(request, HttpResponse.BodyHandlers.ofString());
+        } catch (IOException e) {
+            throw new RuntimeException(e);
+        } catch (InterruptedException e) {
+            throw new RuntimeException(e);
+        }
+        System.out.println(response.body());
+
+        return null;
+    }
+}

--- a/spartanstay/spartanstay/src/main/java/com/spartanstay/spartanstay/controller/ListingsController.java
+++ b/spartanstay/spartanstay/src/main/java/com/spartanstay/spartanstay/controller/ListingsController.java
@@ -22,7 +22,7 @@ public class ListingsController {
         String destId;
         if (destination != null) {
             //TODO: this needs to be a call to locations search, this won't work right now.
-            destId = destination;
+            destId = listingService.getLocationID(destination);
         }
         else {
             destId = "1506246";

--- a/spartanstay/spartanstay/src/main/java/com/spartanstay/spartanstay/service/ListingsService.java
+++ b/spartanstay/spartanstay/src/main/java/com/spartanstay/spartanstay/service/ListingsService.java
@@ -1,4 +1,5 @@
 package com.spartanstay.spartanstay.service;
 
 public interface ListingsService {
+    public String getListings(String destId, String checkIn, String checkOut, String sortOrder);
 }

--- a/spartanstay/spartanstay/src/main/java/com/spartanstay/spartanstay/service/ListingsService.java
+++ b/spartanstay/spartanstay/src/main/java/com/spartanstay/spartanstay/service/ListingsService.java
@@ -1,0 +1,4 @@
+package com.spartanstay.spartanstay.service;
+
+public interface ListingsService {
+}

--- a/spartanstay/spartanstay/src/main/java/com/spartanstay/spartanstay/service/ListingsService.java
+++ b/spartanstay/spartanstay/src/main/java/com/spartanstay/spartanstay/service/ListingsService.java
@@ -2,4 +2,5 @@ package com.spartanstay.spartanstay.service;
 
 public interface ListingsService {
     public String getListings(String destId, String checkIn, String checkOut, String sortOrder);
+    public String getLocationID(String destination);
 }

--- a/spartanstay/spartanstay/src/main/java/com/spartanstay/spartanstay/service/ListingsService.java
+++ b/spartanstay/spartanstay/src/main/java/com/spartanstay/spartanstay/service/ListingsService.java
@@ -1,6 +1,7 @@
 package com.spartanstay.spartanstay.service;
 
 public interface ListingsService {
-    public String getListings(String destId, String checkIn, String checkOut, String sortOrder);
+    public String getListings(String destId, String checkIn, String checkOut, String sortOrder, String adults);
     public String getLocationID(String destination);
+    public String getDetails(String id, String checkIn, String checkOut, String adults);
 }

--- a/spartanstay/spartanstay/src/main/java/com/spartanstay/spartanstay/service/ListingsServiceImpl.java
+++ b/spartanstay/spartanstay/src/main/java/com/spartanstay/spartanstay/service/ListingsServiceImpl.java
@@ -1,4 +1,41 @@
 package com.spartanstay.spartanstay.service;
 
+import java.io.IOException;
+import java.net.URI;
+import java.net.http.HttpClient;
+import java.net.http.HttpRequest;
+import java.net.http.HttpResponse;
+
 public class ListingsServiceImpl implements ListingsService{
+
+    @Override
+    public String getListings(String destId, String checkIn, String checkOut, String sortOrder ) {
+        HttpRequest request = HttpRequest.newBuilder()
+                .uri(URI.create("https://hotels4.p.rapidapi.com/properties/list?destinationId="+ destId +
+                        "&pageNumber=1&pageSize=25" +
+                        "&checkIn="+checkIn+
+                        "&checkOut="+checkOut+
+                        "&adults1=1" +
+                        "&sortOrder=" + sortOrder +
+                        "&locale=en_US&currency=USD"))
+                .header("X-RapidAPI-Key", Secrets.API_KEY)
+                .header("X-RapidAPI-Host", "hotels4.p.rapidapi.com")
+                .method("GET", HttpRequest.BodyPublishers.noBody())
+                .build();
+        HttpResponse<String> response = null;
+        try {
+            response = HttpClient.newHttpClient().send(request, HttpResponse.BodyHandlers.ofString());
+        } catch (IOException e) {
+            throw new RuntimeException(e);
+        } catch (InterruptedException e) {
+            throw new RuntimeException(e);
+        }
+        System.out.println(response.body());
+
+        if(response != null) {
+            return response.body().toString();
+        }
+        return "{Response was null}";
+
+    }
 }

--- a/spartanstay/spartanstay/src/main/java/com/spartanstay/spartanstay/service/ListingsServiceImpl.java
+++ b/spartanstay/spartanstay/src/main/java/com/spartanstay/spartanstay/service/ListingsServiceImpl.java
@@ -6,6 +6,10 @@ import java.net.http.HttpClient;
 import java.net.http.HttpRequest;
 import java.net.http.HttpResponse;
 
+import org.json.JSONArray;
+import org.json.JSONException;
+import org.json.JSONObject;
+
 public class ListingsServiceImpl implements ListingsService{
 
     @Override
@@ -37,5 +41,32 @@ public class ListingsServiceImpl implements ListingsService{
         }
         return "{Response was null}";
 
+    }
+
+    @Override
+    public String getLocationID(String destination) {
+        destination = destination.replaceAll(" ", "%20");
+        HttpRequest request = HttpRequest.newBuilder()
+                .uri(URI.create("https://hotels4.p.rapidapi.com/locations/v2/search?query=" + destination +
+                        "&locale=en_US&currency=USD"))
+                .header("X-RapidAPI-Key", Secrets.API_KEY)
+                .header("X-RapidAPI-Host", "hotels4.p.rapidapi.com")
+                .method("GET", HttpRequest.BodyPublishers.noBody())
+                .build();
+        HttpResponse<String> response = null;
+        try {
+            response = HttpClient.newHttpClient().send(request, HttpResponse.BodyHandlers.ofString());
+        } catch (IOException e) {
+            e.printStackTrace();
+        } catch (InterruptedException e) {
+            e.printStackTrace();
+        }
+
+        if(response != null) {
+            JSONObject json = new JSONObject(response.body());
+            return json.getJSONArray("suggestions").getJSONObject(0)
+                    .getJSONArray("entities").getJSONObject(0).getString("destinationId");
+        }
+        return "{No response from location search}";
     }
 }

--- a/spartanstay/spartanstay/src/main/java/com/spartanstay/spartanstay/service/ListingsServiceImpl.java
+++ b/spartanstay/spartanstay/src/main/java/com/spartanstay/spartanstay/service/ListingsServiceImpl.java
@@ -11,13 +11,13 @@ import org.json.JSONObject;
 public class ListingsServiceImpl implements ListingsService{
 
     @Override
-    public String getListings(String destId, String checkIn, String checkOut, String sortOrder ) {
+    public String getListings(String destId, String checkIn, String checkOut, String sortOrder, String adults) {
         HttpRequest request = HttpRequest.newBuilder()
                 .uri(URI.create("https://hotels4.p.rapidapi.com/properties/list?destinationId="+ destId +
                         "&pageNumber=1&pageSize=25" +
                         "&checkIn="+checkIn+
                         "&checkOut="+checkOut+
-                        "&adults1=1" +
+                        "&adults1=" + adults +
                         "&sortOrder=" + sortOrder +
                         "&locale=en_US&currency=USD"))
                 .header("X-RapidAPI-Key", Secrets.API_KEY)
@@ -68,5 +68,35 @@ public class ListingsServiceImpl implements ListingsService{
                     .getJSONArray("entities").getJSONObject(0).getString("destinationId");
         }
         return "{No response from location search.}";
+    }
+
+    @Override
+    public String getDetails(String id, String checkIn, String checkOut, String adults) {
+        HttpRequest request = HttpRequest.newBuilder()
+                .uri(URI.create("https://hotels4.p.rapidapi.com/properties/get-details?id="+ id +
+                        "&checkIn="+checkIn+
+                        "&checkOut="+checkOut+
+                        "&adults1=" + adults +
+                        "&locale=en_US&currency=USD"))
+                .header("X-RapidAPI-Key", Secrets.API_KEY)
+                .header("X-RapidAPI-Host", "hotels4.p.rapidapi.com")
+                .method("GET", HttpRequest.BodyPublishers.noBody())
+                .build();
+        HttpResponse<String> response = null;
+        try {
+            response = HttpClient.newHttpClient().send(request, HttpResponse.BodyHandlers.ofString());
+        } catch (IOException e) {
+            throw new RuntimeException(e);
+        } catch (InterruptedException e) {
+            throw new RuntimeException(e);
+        }
+        System.out.println(response.body());
+
+        if(response != null) {
+            return response.body();
+        }
+        return "{No response from details search.}";
+
+
     }
 }

--- a/spartanstay/spartanstay/src/main/java/com/spartanstay/spartanstay/service/ListingsServiceImpl.java
+++ b/spartanstay/spartanstay/src/main/java/com/spartanstay/spartanstay/service/ListingsServiceImpl.java
@@ -6,8 +6,6 @@ import java.net.http.HttpClient;
 import java.net.http.HttpRequest;
 import java.net.http.HttpResponse;
 
-import org.json.JSONArray;
-import org.json.JSONException;
 import org.json.JSONObject;
 
 public class ListingsServiceImpl implements ListingsService{
@@ -37,9 +35,11 @@ public class ListingsServiceImpl implements ListingsService{
         System.out.println(response.body());
 
         if(response != null) {
-            return response.body().toString();
+            JSONObject json = new JSONObject((response.body()));
+            return json.getJSONObject("data").getJSONObject("body")
+                    .getJSONObject("searchResults").getJSONArray("results").toString();
         }
-        return "{Response was null}";
+        return "{No response from listings search.}";
 
     }
 
@@ -67,6 +67,6 @@ public class ListingsServiceImpl implements ListingsService{
             return json.getJSONArray("suggestions").getJSONObject(0)
                     .getJSONArray("entities").getJSONObject(0).getString("destinationId");
         }
-        return "{No response from location search}";
+        return "{No response from location search.}";
     }
 }

--- a/spartanstay/spartanstay/src/main/java/com/spartanstay/spartanstay/service/ListingsServiceImpl.java
+++ b/spartanstay/spartanstay/src/main/java/com/spartanstay/spartanstay/service/ListingsServiceImpl.java
@@ -1,0 +1,4 @@
+package com.spartanstay.spartanstay.service;
+
+public class ListingsServiceImpl implements ListingsService{
+}


### PR DESCRIPTION
Two new endpoints (listings/hotels, listings/details) get data from hotels4 API to enable us to display real listings and respond to a broad range of search without hand creating records for our database. The data is currently returned as JSON strings, which should be ideal for React to parse into JS objects. 

https://rapidapi.com/apidojo/api/hotels4

Message Vanessa or myself to get the API key for this.

Examples: 
http://localhost:8080/listings/details?id=260158&checkIn=2022-12-25&checkOut=2022-12-26

http://localhost:8080/listings/rooms?destination=new%20york&checkIn=2022-12-25&checkOut=2022-12-26

You should be able to enter any city in the US and any two dates in the future and get valid results. Not tested for a checkOut date that is earlier than a checkIn date, but that should be validated in React before attempting to use this data. 